### PR TITLE
feat: section figures + acceptable-model ensemble (UQ)

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,44 @@ densigrav section talwani-invert \
 
 Requires `scipy` (install `.[grid]`).
 
+### Publication figures: `section plot` / `section ensemble`
+
+Render a publication-quality 2-panel section figure — observed vs. calculated
+gravity on top, the 2-D density-contrast model (with surface topography) on the
+bottom — directly from a `profile.csv` and a model YAML. The calculated curve
+and the misfit statistics are recomputed from the model, so the figure always
+matches the model file.
+
+```bash
+densigrav section plot \
+  --model results/talwani/model_shinshiro_simple.yaml \
+  --profile results/2d/section_A/profile.csv \
+  --value-col residual_mgal \
+  --section-name "Shinshiro" \
+  --exclude-dist 4305.5 \
+  --out results/figures/section.png
+```
+
+To visualize inversion **non-uniqueness**, `section ensemble` runs a
+Monte-Carlo parametric bootstrap (perturb the data by `--sigma`, re-fit a
+surface-topped trapezoid `--n` times, and keep the solutions within
+`--accept-factor` of the best RMS). It draws a *body-presence probability* map
+plus a 5–95 % predictive envelope of the calculated anomaly:
+
+```bash
+densigrav section ensemble \
+  --model results/talwani/model_shinshiro_simple.yaml \
+  --profile results/2d/section_A/profile.csv \
+  --value-col residual_mgal --section-name "Shinshiro" \
+  --exclude-dist 4305.5 --sigma 0.8 --n 600 --accept-factor 1.2 \
+  --out results/figures/section_ensemble.png
+```
+
+Both write a sibling `.pdf`; `ensemble` also writes `<out>_params.csv`.
+Requires `matplotlib` (`.[viz]`) and, for `ensemble`, `scipy` (`.[grid]`).
+(The same figures are available without installing, via
+`scripts/plot_section_model.py` and `scripts/ensemble_section.py`.)
+
 ---
 
 ## Optional utilities

--- a/scripts/ensemble_section.py
+++ b/scripts/ensemble_section.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Thin wrapper around densigrav.section.ensemble.run_ensemble.
+
+Prefer the installed CLI:  densigrav section ensemble --help
+This script lets you run the same ensemble figure without installing the package.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from densigrav.section.ensemble import run_ensemble  # noqa: E402
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--model", required=True, type=Path)
+    ap.add_argument("--profile", required=True, type=Path)
+    ap.add_argument("--out", required=True, type=Path)
+    ap.add_argument("--value-col", default="residual_mgal")
+    ap.add_argument("--section-name", default="Section")
+    ap.add_argument("--exclude-dist", type=float, nargs="*", default=[])
+    ap.add_argument("--exclude-tol", type=float, default=2.0)
+    ap.add_argument("--sigma", type=float, default=0.8)
+    ap.add_argument("--n", type=int, default=400)
+    ap.add_argument("--accept-factor", type=float, default=1.2)
+    ap.add_argument("--seed", type=int, default=0)
+    a = ap.parse_args()
+
+    s = run_ensemble(
+        a.model,
+        a.profile,
+        a.out,
+        value_col=a.value_col,
+        section_name=a.section_name,
+        exclude_dist=a.exclude_dist,
+        exclude_tol=a.exclude_tol,
+        sigma=a.sigma,
+        n=a.n,
+        accept_factor=a.accept_factor,
+        seed=a.seed,
+    )
+    print(f"Saved: {s['out']}")
+    print(f"Saved: {s['pdf']}")
+    print(f"Saved ensemble parameters: {s['params_csv']}")
+    print(
+        f"  draws={s['n_draws']}, accepted={s['n_accepted']} at RMS <= "
+        f"{a.accept_factor:.2f} x {s['best_rms_mgal']:.2f} mGal"
+    )
+    bd, cx = s["base_depth_m"], s["center_x0_m"]
+    print(
+        f"  best-fit: x0={s['best_center_x0_m']:.0f} m, base depth={s['best_base_depth_m']:.0f} m, "
+        f"RMS={s['rms_mgal']:.2f} mGal, VR={s['variance_reduction_pct']:.0f}%"
+    )
+    print(f"  base depth = {bd[0]:.0f} [{bd[1]:.0f}, {bd[2]:.0f}] m (5-95%)")
+    print(f"  center x0  = {cx[0]:.0f} [{cx[1]:.0f}, {cx[2]:.0f}] m (5-95%)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/plot_section_model.py
+++ b/scripts/plot_section_model.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Thin wrapper around densigrav.section.plotting.plot_section_model.
+
+Prefer the installed CLI:  densigrav section plot --help
+This script lets you run the same figure without installing the package.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from densigrav.section.plotting import plot_section_model  # noqa: E402
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--model", required=True, type=Path)
+    ap.add_argument("--profile", required=True, type=Path)
+    ap.add_argument("--out", required=True, type=Path)
+    ap.add_argument("--value-col", default="residual_mgal")
+    ap.add_argument("--section-name", default="Section")
+    ap.add_argument("--exclude-dist", type=float, nargs="*", default=[])
+    ap.add_argument("--exclude-tol", type=float, default=2.0)
+    ap.add_argument("--obs-height", choices=["sealevel", "elev"], default="sealevel")
+    ap.add_argument("--equal-aspect", action="store_true")
+    a = ap.parse_args()
+
+    s = plot_section_model(
+        a.model,
+        a.profile,
+        a.out,
+        value_col=a.value_col,
+        section_name=a.section_name,
+        exclude_dist=a.exclude_dist,
+        exclude_tol=a.exclude_tol,
+        obs_height=a.obs_height,
+        equal_aspect=a.equal_aspect,
+    )
+    print(f"Saved: {s['out']}")
+    print(f"Saved: {s['pdf']}")
+    print(
+        f"  RMS misfit = {s['rms_mgal']:.3f} mGal | variance reduction = "
+        f"{s['variance_reduction_pct']:.1f}% | N = {s['n']}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/densigrav/cli.py
+++ b/src/densigrav/cli.py
@@ -7,6 +7,8 @@ from typing import Optional
 
 import numpy as np
 
+from densigrav.section.ensemble import run_ensemble
+from densigrav.section.plotting import plot_section_model
 from densigrav.section.profile import extract_section_profile
 from densigrav.section.talwani2d import talwani_gz_polygon
 from densigrav.section.talwani_io import load_talwani_model, save_talwani_model
@@ -78,6 +80,65 @@ def build_parser() -> argparse.ArgumentParser:
     p_ti.add_argument("--drho", type=float, default=300.0, help="Density contrast (kg/m^3), fixed")
     p_ti.add_argument("--out-model", type=Path, required=True, help="Output model yaml")
     p_ti.add_argument("--overwrite", action="store_true")
+
+    # section plot (publication figure)
+    p_pl = sp_section.add_parser(
+        "plot", help="Publication 2D section figure (gravity fit + density model)"
+    )
+    p_pl.add_argument(
+        "--profile", type=Path, required=True, help="profile.csv (from section extract)"
+    )
+    p_pl.add_argument("--model", type=Path, required=True, help="talwani model yaml")
+    p_pl.add_argument(
+        "--out", type=Path, required=True, help="Output image (png; pdf is also written)"
+    )
+    p_pl.add_argument(
+        "--value-col", type=str, default="residual_mgal", help="Observed gravity column"
+    )
+    p_pl.add_argument("--section-name", type=str, default="Section")
+    p_pl.add_argument(
+        "--exclude-dist",
+        type=float,
+        nargs="*",
+        default=[],
+        help="dist_m value(s) to flag as excluded outliers",
+    )
+    p_pl.add_argument("--exclude-tol", type=float, default=2.0, help="match tolerance (m)")
+    p_pl.add_argument(
+        "--use-elev",
+        action="store_true",
+        help="Use -elev_m as observation height (else sea level z=0)",
+    )
+    p_pl.add_argument(
+        "--equal-aspect",
+        action="store_true",
+        help="1:1 aspect (no vertical exaggeration) for the model panel",
+    )
+
+    # section ensemble (uncertainty figure)
+    p_en = sp_section.add_parser(
+        "ensemble", help="Acceptable-model ensemble + uncertainty figure (non-uniqueness)"
+    )
+    p_en.add_argument("--profile", type=Path, required=True, help="profile.csv")
+    p_en.add_argument(
+        "--model", type=Path, required=True, help="talwani model yaml (best-fit body)"
+    )
+    p_en.add_argument(
+        "--out", type=Path, required=True, help="Output image (png; pdf + params csv also written)"
+    )
+    p_en.add_argument("--value-col", type=str, default="residual_mgal")
+    p_en.add_argument("--section-name", type=str, default="Section")
+    p_en.add_argument("--exclude-dist", type=float, nargs="*", default=[])
+    p_en.add_argument("--exclude-tol", type=float, default=2.0)
+    p_en.add_argument("--sigma", type=float, default=0.8, help="data noise std (mGal)")
+    p_en.add_argument("--n", type=int, default=400, help="ensemble size (draws)")
+    p_en.add_argument(
+        "--accept-factor",
+        type=float,
+        default=1.2,
+        help="keep models with RMS(obs) <= factor * best RMS",
+    )
+    p_en.add_argument("--seed", type=int, default=0)
 
     # project
     project_p = sub.add_parser("project", help="Project utilities")
@@ -542,6 +603,54 @@ def main(argv: Optional[list[str]] = None) -> int:
                 print(f"value_col: {value_col}")
                 print(f"out_model: {args.out_model}")
                 print(f"rmse_mgal: {stats['rmse_mgal']:.4f}, nfev: {int(stats['nfev'])}")
+                return 0
+
+            if args.section_cmd == "plot":
+                stats = plot_section_model(
+                    args.model,
+                    args.profile,
+                    args.out,
+                    value_col=args.value_col,
+                    section_name=args.section_name,
+                    exclude_dist=args.exclude_dist,
+                    exclude_tol=args.exclude_tol,
+                    obs_height="elev" if args.use_elev else "sealevel",
+                    equal_aspect=bool(args.equal_aspect),
+                )
+                print("OK: section figure")
+                print(f"out: {stats['out']}")
+                print(f"pdf: {stats['pdf']}")
+                print(
+                    f"RMS={stats['rms_mgal']:.3f} mGal, "
+                    f"variance_reduction={stats['variance_reduction_pct']:.1f}%, N={stats['n']}"
+                )
+                return 0
+
+            if args.section_cmd == "ensemble":
+                s = run_ensemble(
+                    args.model,
+                    args.profile,
+                    args.out,
+                    value_col=args.value_col,
+                    section_name=args.section_name,
+                    exclude_dist=args.exclude_dist,
+                    exclude_tol=args.exclude_tol,
+                    sigma=args.sigma,
+                    n=args.n,
+                    accept_factor=args.accept_factor,
+                    seed=args.seed,
+                )
+                print("OK: section ensemble")
+                print(f"out: {s['out']}")
+                print(f"pdf: {s['pdf']}")
+                print(f"params_csv: {s['params_csv']}")
+                print(
+                    f"accepted={s['n_accepted']}/{s['n_draws']}, "
+                    f"best RMS={s['best_rms_mgal']:.2f} mGal, VR={s['variance_reduction_pct']:.0f}%"
+                )
+                bd, cx = s["base_depth_m"], s["center_x0_m"]
+                print(f"base depth = {bd[0]:.0f} m [{bd[1]:.0f}, {bd[2]:.0f}] (5-95%)")
+                print(f"center x0  = {cx[0]:.0f} m [{cx[1]:.0f}, {cx[2]:.0f}] (5-95%)")
                 return 0
 
         parser.print_help()

--- a/src/densigrav/section/ensemble.py
+++ b/src/densigrav/section/ensemble.py
@@ -1,0 +1,307 @@
+"""Acceptable-model ensemble for a 2-D gravity section (honest non-uniqueness).
+
+Monte-Carlo error propagation: perturb the observed anomaly with Gaussian
+noise, re-fit a surface-topped trapezoid from randomized starts, and keep the
+solutions that fit the observed data essentially as well as the best model.
+The accepted family is summarized as a body-presence probability map and a
+5-95 % predictive envelope of the calculated anomaly.
+
+scipy / matplotlib are imported lazily so the package stays importable without
+the optional ``grid`` / ``viz`` extras.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+
+import numpy as np
+
+from .plotting import load_model
+from .talwani2d import talwani_gz_polygon
+
+KM = 1e-3
+
+
+def trapezoid(x0: float, ht: float, hb: float, zb: float, zt: float = 0.0) -> np.ndarray:
+    """Surface-topped trapezoid: top half-width ht at depth zt, base half-width hb at depth zb."""
+    return np.array([[x0 - ht, zt], [x0 + ht, zt], [x0 + hb, zb], [x0 - hb, zb]], dtype=float)
+
+
+def _fit_trapezoid(least_squares, x, y, z, drho, p0, lo, hi):
+    def res(p):
+        x0, ht, hb, zb = p
+        if zb <= 60.0:
+            return 1e6 * np.ones_like(y)
+        return talwani_gz_polygon(x, z, trapezoid(x0, ht, hb, zb), drho) - y
+
+    return least_squares(res, p0, bounds=(lo, hi), max_nfev=400).x
+
+
+def run_ensemble(
+    model: Path,
+    profile: Path,
+    out: Path,
+    *,
+    value_col: str = "residual_mgal",
+    section_name: str = "Section",
+    exclude_dist: Iterable[float] = (),
+    exclude_tol: float = 2.0,
+    sigma: float = 0.8,
+    n: int = 400,
+    accept_factor: float = 1.2,
+    seed: int = 0,
+) -> dict:
+    """Run the ensemble, render the uncertainty figure, and write the parameter CSV."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    import pandas as pd
+    from matplotlib.path import Path as MplPath
+    from scipy.optimize import least_squares
+
+    model, profile, out = Path(model), Path(profile), Path(out)
+    drho, best_verts = load_model(model)
+
+    df = pd.read_csv(profile)
+    dist = df["dist_m"].to_numpy(dtype=float)
+    obs = df[value_col].to_numpy(dtype=float)
+    elev = df["elev_m"].to_numpy(dtype=float) if "elev_m" in df.columns else np.zeros_like(dist)
+
+    excl = np.zeros(len(dist), dtype=bool)
+    for xd in exclude_dist:
+        excl |= np.abs(dist - xd) <= exclude_tol
+    keep = ~excl
+    xk, yk = dist[keep], obs[keep]
+    zk = np.zeros_like(xk)
+
+    # parameter bounds (geological priors): top fixed at sea level (z=0)
+    xmin, xmax = float(dist.min()), float(dist.max())
+    lo = np.array([xmin + 200.0, 200.0, 100.0, 200.0])
+    hi = np.array([xmax + 800.0, 3500.0, 3500.0, 4000.0])
+
+    rng = np.random.default_rng(seed)
+
+    def _rms(p):
+        return float(np.sqrt(np.mean((yk - talwani_gz_polygon(xk, zk, trapezoid(*p), drho)) ** 2)))
+
+    # robust best fit via several starts (the misfit surface is non-convex; a single
+    # generic start can converge to a poor local minimum)
+    x0_peak = float(xk[np.argmax(np.abs(yk))])
+    start_centers = [
+        x0_peak,
+        0.5 * (xmin + xmax),
+        xmin + 0.25 * (xmax - xmin),
+        xmin + 0.75 * (xmax - xmin),
+    ]
+    best_p, best_rms = None, np.inf
+    for xc in start_centers:
+        p0 = np.clip(np.array([xc, 1500.0, 1000.0, 1500.0]), lo, hi)
+        cand = _fit_trapezoid(least_squares, xk, yk, zk, drho, p0, lo, hi)
+        r = _rms(cand)
+        if r < best_rms:
+            best_rms, best_p = r, cand
+    p0_best = best_p.copy()
+
+    raw = np.empty((n, 4))
+    rms_obs = np.empty(n)
+    for k in range(n):
+        yp = yk + rng.normal(0.0, sigma, size=yk.shape)
+        start = np.clip(p0_best * (1.0 + rng.normal(0.0, 0.25, size=4)), lo, hi)
+        try:
+            raw[k] = _fit_trapezoid(least_squares, xk, yp, zk, drho, start, lo, hi)
+        except Exception:
+            raw[k] = best_p
+        rms_obs[k] = _rms(raw[k])
+
+    accepted = rms_obs <= accept_factor * best_rms
+    params = raw[accepted]
+    n_acc = int(accepted.sum())
+    if n_acc < 10:
+        raise ValueError(f"Too few acceptable models ({n_acc}); loosen accept_factor or raise n")
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+    ens_csv = out.parent / (out.stem + "_params.csv")
+    pd.DataFrame(
+        params, columns=["x0_m", "halfwidth_top_m", "halfwidth_base_m", "base_depth_m"]
+    ).to_csv(ens_csv, index=False)
+
+    # predictive gravity envelope on a dense grid
+    xpad = 0.04 * (dist.max() - dist.min())
+    x_lo = min(dist.min(), best_verts[:, 0].min()) - xpad
+    x_hi = max(dist.max(), best_verts[:, 0].max()) + xpad
+    xd = np.linspace(x_lo, x_hi, 400)
+    zd = np.zeros_like(xd)
+    curves = np.empty((n_acc, xd.size))
+    for k in range(n_acc):
+        curves[k] = talwani_gz_polygon(xd, zd, trapezoid(*params[k]), drho)
+    q05, q95 = np.percentile(curves, [5, 95], axis=0)
+    best_curve = talwani_gz_polygon(xd, zd, trapezoid(*best_p), drho)
+
+    pred_best_st = talwani_gz_polygon(xk, zk, trapezoid(*best_p), drho)
+    rms = float(np.sqrt(np.mean((yk - pred_best_st) ** 2)))
+    vr = float(100.0 * (1.0 - np.var(yk - pred_best_st) / np.var(yk)))
+
+    # body-presence probability on an (x,z) grid
+    zb_hi = float(np.percentile(params[:, 3], 99)) * 1.08
+    gx = np.linspace(x_lo, x_hi, 240)
+    gz = np.linspace(0.0, zb_hi, 150)
+    GX, GZ = np.meshgrid(gx, gz)
+    pts = np.column_stack([GX.ravel(), GZ.ravel()])
+    inside = np.zeros(pts.shape[0], dtype=float)
+    for k in range(n_acc):
+        inside += MplPath(trapezoid(*params[k])).contains_points(pts)
+    prob = (inside / n_acc).reshape(GX.shape)
+    prob_masked = np.ma.masked_less(prob, 0.05)
+
+    # ---------------- figure ----------------
+    plt.rcParams.update({"font.size": 10, "axes.linewidth": 0.8})
+    fig, (axg, axm) = plt.subplots(
+        2, 1, figsize=(7.5, 6.6), sharex=True, gridspec_kw={"height_ratios": [1.0, 1.5]}
+    )
+
+    axg.fill_between(
+        xd * KM,
+        q05,
+        q95,
+        color="#c0392b",
+        alpha=0.20,
+        lw=0,
+        label="Calculated (5–95 % of ensemble)",
+        zorder=2,
+    )
+    axg.plot(xd * KM, best_curve, "-", color="#c0392b", lw=2.0, zorder=3, label="Best-fit model")
+    axg.scatter(
+        xk * KM,
+        yk,
+        s=44,
+        facecolor="#2c3e50",
+        edgecolor="white",
+        linewidth=0.6,
+        zorder=4,
+        label="Observed (residual)",
+    )
+    if excl.any():
+        axg.scatter(
+            dist[excl] * KM,
+            obs[excl],
+            s=48,
+            facecolor="none",
+            edgecolor="#95a5a6",
+            linewidth=1.3,
+            zorder=4,
+            label="Excluded outlier",
+        )
+    axg.axhline(0.0, color="0.6", lw=0.8)
+    axg.set_ylabel("Residual Bouguer\nanomaly (mGal)")
+    axg.grid(alpha=0.25)
+    axg.legend(loc="upper left", fontsize=7.5, framealpha=0.92)
+    stats = (
+        f"$\\Delta\\rho$ = {drho:+.0f} kg m$^{{-3}}$ (fixed)\n"
+        f"RMS misfit = {rms:.2f} mGal\n"
+        f"Variance reduction = {vr:.0f}%\n"
+        f"noise $\\sigma$ = {sigma:.1f} mGal,  N = {int(keep.sum())}"
+    )
+    axg.text(
+        0.985,
+        0.06,
+        stats,
+        transform=axg.transAxes,
+        ha="right",
+        va="bottom",
+        fontsize=7.5,
+        bbox=dict(boxstyle="round", fc="white", ec="0.7", alpha=0.92),
+    )
+    axg.set_title(f"{section_name}  —  2-D gravity model with uncertainty", fontsize=11, loc="left")
+
+    order = np.argsort(dist)
+    topo_z = -elev[order] * KM
+    axm.fill_between(dist[order] * KM, topo_z, 0.0, color="#efe7dd", zorder=0)
+    axm.plot(dist[order] * KM, topo_z, color="#6e4b3a", lw=1.4, zorder=6, label="Ground surface")
+
+    pcm = axm.pcolormesh(
+        gx * KM, gz * KM, prob_masked, cmap="YlOrRd", vmin=0.0, vmax=1.0, shading="auto", zorder=2
+    )
+    cs = axm.contour(
+        GX * KM,
+        GZ * KM,
+        prob,
+        levels=[0.25, 0.5, 0.75],
+        colors="#7b241c",
+        linewidths=[0.6, 0.9, 0.6],
+        linestyles=["dotted", "solid", "dashed"],
+        zorder=4,
+    )
+    axm.clabel(cs, fmt={0.25: "25%", 0.5: "50%", 0.75: "75%"}, fontsize=6.5, inline=True)
+    axm.plot(
+        np.append(best_verts[:, 0], best_verts[0, 0]) * KM,
+        np.append(best_verts[:, 1], best_verts[0, 1]) * KM,
+        color="#1b2631",
+        lw=1.8,
+        zorder=5,
+        label="Best-fit body",
+    )
+    axm.axhline(0.0, color="#34607d", lw=0.9, ls="--", zorder=3)
+    axm.text(x_lo * KM, 0.0, " sea level", color="#34607d", fontsize=7.5, va="bottom", ha="left")
+
+    axm.set_ylabel("Depth below sea level (km)")
+    axm.set_xlabel("Distance along section (km)")
+    axm.grid(alpha=0.2)
+    axm.set_xlim(x_lo * KM, x_hi * KM)
+    emax = float(elev.max()) * KM
+    axm.set_ylim(-(emax * 1.5 + 0.05), zb_hi * KM)
+    axm.invert_yaxis()
+    axm.legend(loc="lower left", fontsize=7.5, framealpha=0.92)
+
+    cbar = fig.colorbar(pcm, ax=axm, pad=0.012, fraction=0.045)
+    cbar.set_label("Model support\nP(inside body)", fontsize=8)
+    cbar.ax.tick_params(labelsize=7.5)
+
+    bbox = axm.get_position()
+    w_in = fig.get_figwidth() * bbox.width
+    h_in = fig.get_figheight() * bbox.height
+    dx = (x_hi - x_lo) * KM
+    dz = (zb_hi * KM) + (emax * 1.5 + 0.05)
+    ve = (dz / h_in) / (dx / w_in)
+    axm.text(
+        0.985,
+        0.04,
+        f"vertical exaggeration ≈ {ve:.1f}×",
+        transform=axm.transAxes,
+        ha="right",
+        va="bottom",
+        fontsize=7.5,
+        color="0.35",
+        style="italic",
+    )
+
+    fig.tight_layout()
+    fig.savefig(out, dpi=300)
+    pdf = out.with_suffix(".pdf")
+    fig.savefig(pdf)
+    plt.close(fig)
+
+    def _ci(col):
+        return (
+            float(np.median(params[:, col])),
+            float(np.percentile(params[:, col], 5)),
+            float(np.percentile(params[:, col], 95)),
+        )
+
+    return {
+        "out": str(out),
+        "pdf": str(pdf),
+        "params_csv": str(ens_csv),
+        "n_draws": int(n),
+        "n_accepted": n_acc,
+        "best_rms_mgal": best_rms,
+        "rms_mgal": rms,
+        "variance_reduction_pct": vr,
+        "best_base_depth_m": float(best_p[3]),
+        "best_center_x0_m": float(best_p[0]),
+        "center_x0_m": _ci(0),
+        "base_depth_m": _ci(3),
+        "halfwidth_top_m": _ci(1),
+        "halfwidth_base_m": _ci(2),
+    }

--- a/src/densigrav/section/plotting.py
+++ b/src/densigrav/section/plotting.py
@@ -1,0 +1,209 @@
+"""Publication-quality 2-D gravity section figure (gravity fit + density model).
+
+The calculated curve and misfit statistics are recomputed from the model
+polygon, so the figure is always consistent with the model file (it never
+relies on a possibly-stale ``talwani_pred_mgal`` column).
+
+matplotlib is imported lazily so the package stays importable without the
+optional ``viz`` extra.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+
+import numpy as np
+import yaml
+
+from .talwani2d import talwani_gz_polygon
+
+KM = 1e-3
+
+
+def load_model(path: Path) -> tuple[float, np.ndarray]:
+    data = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+    drho = float(data["density_contrast_kgm3"])
+    verts = np.asarray(data["vertices_xz_m"], dtype=float)
+    if verts.ndim != 2 or verts.shape[1] != 2 or verts.shape[0] < 3:
+        raise ValueError("vertices_xz_m must be a list of >=3 [x, z] pairs")
+    return drho, verts
+
+
+def plot_section_model(
+    model: Path,
+    profile: Path,
+    out: Path,
+    *,
+    value_col: str = "residual_mgal",
+    section_name: str = "Section",
+    exclude_dist: Iterable[float] = (),
+    exclude_tol: float = 2.0,
+    obs_height: str = "sealevel",
+    equal_aspect: bool = False,
+) -> dict:
+    """Render the 2-panel section figure (png + sibling pdf). Returns misfit stats."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    import pandas as pd
+
+    model, profile, out = Path(model), Path(profile), Path(out)
+    drho, verts = load_model(model)
+
+    df = pd.read_csv(profile)
+    if "dist_m" not in df.columns or value_col not in df.columns:
+        raise ValueError(f"profile must contain 'dist_m' and '{value_col}'")
+
+    dist = df["dist_m"].to_numpy(dtype=float)
+    obs = df[value_col].to_numpy(dtype=float)
+    elev = df["elev_m"].to_numpy(dtype=float) if "elev_m" in df.columns else np.zeros_like(dist)
+
+    excl = np.zeros(len(dist), dtype=bool)
+    for xd in exclude_dist:
+        excl |= np.abs(dist - xd) <= exclude_tol
+    keep = ~excl
+
+    z_obs = (-elev) if obs_height == "elev" else np.zeros_like(dist)
+
+    # recompute calculated gravity from the model (stations + dense curve)
+    pred_st = talwani_gz_polygon(dist, z_obs, verts, drho)
+    res = obs - pred_st
+    rms = float(np.sqrt(np.mean(res[keep] ** 2)))
+    vr = float(100.0 * (1.0 - np.var(res[keep]) / np.var(obs[keep])))
+
+    xpad = 0.04 * (dist.max() - dist.min())
+    x_lo = min(dist.min(), verts[:, 0].min()) - xpad
+    x_hi = max(dist.max(), verts[:, 0].max()) + xpad
+    xd = np.linspace(x_lo, x_hi, 500)
+    pred_dense = talwani_gz_polygon(xd, np.zeros_like(xd), verts, drho)
+
+    plt.rcParams.update({"font.size": 10, "axes.linewidth": 0.8})
+    fig, (axg, axm) = plt.subplots(
+        2, 1, figsize=(7.5, 6.4), sharex=True, gridspec_kw={"height_ratios": [1.0, 1.5]}
+    )
+
+    # (top) gravity panel
+    axg.plot(xd * KM, pred_dense, "-", color="#c0392b", lw=2.0, zorder=3, label="Calculated")
+    axg.scatter(
+        dist[keep] * KM,
+        obs[keep],
+        s=44,
+        facecolor="#2c3e50",
+        edgecolor="white",
+        linewidth=0.6,
+        zorder=4,
+        label="Observed (residual)",
+    )
+    if excl.any():
+        axg.scatter(
+            dist[excl] * KM,
+            obs[excl],
+            s=48,
+            facecolor="none",
+            edgecolor="#95a5a6",
+            linewidth=1.3,
+            zorder=4,
+            label="Excluded outlier",
+        )
+    axg.axhline(0.0, color="0.6", lw=0.8)
+    axg.set_ylabel("Residual Bouguer\nanomaly (mGal)")
+    axg.grid(alpha=0.25)
+    axg.legend(loc="upper left", fontsize=8, framealpha=0.92)
+    stats = (
+        f"$\\Delta\\rho$ = {drho:+.0f} kg m$^{{-3}}$\n"
+        f"RMS misfit = {rms:.2f} mGal\n"
+        f"Variance reduction = {vr:.0f}%\n"
+        f"N = {int(keep.sum())}"
+    )
+    axg.text(
+        0.985,
+        0.06,
+        stats,
+        transform=axg.transAxes,
+        ha="right",
+        va="bottom",
+        fontsize=8,
+        bbox=dict(boxstyle="round", fc="white", ec="0.7", alpha=0.92),
+    )
+    axg.set_title(f"{section_name}  —  2-D gravity model", fontsize=11, loc="left")
+
+    # (bottom) model panel
+    order = np.argsort(dist)
+    topo_z = -elev[order] * KM
+    axm.fill_between(dist[order] * KM, topo_z, 0.0, color="#efe7dd", zorder=0)
+    axm.plot(dist[order] * KM, topo_z, color="#6e4b3a", lw=1.4, zorder=5, label="Ground surface")
+
+    body_color = "#d9544d" if drho > 0 else "#3b7dd8"
+    edge_color = "#922b21" if drho > 0 else "#1f4e79"
+    axm.fill(
+        verts[:, 0] * KM,
+        verts[:, 1] * KM,
+        facecolor=body_color,
+        alpha=0.40,
+        edgecolor=edge_color,
+        linewidth=2.0,
+        zorder=3,
+    )
+    cx = float(verts[:, 0].mean()) * KM
+    cz = float(verts[:, 1].mean()) * KM
+    axm.text(
+        cx,
+        cz,
+        f"$\\Delta\\rho$ = {drho:+.0f}\nkg m$^{{-3}}$",
+        ha="center",
+        va="center",
+        fontsize=9.5,
+        color=edge_color,
+        zorder=6,
+    )
+    axm.axhline(0.0, color="#34607d", lw=0.9, ls="--", zorder=2)
+    axm.text(x_lo * KM, 0.0, " sea level", color="#34607d", fontsize=7.5, va="bottom", ha="left")
+
+    axm.set_ylabel("Depth below sea level (km)")
+    axm.set_xlabel("Distance along section (km)")
+    axm.grid(alpha=0.25)
+    axm.set_xlim(x_lo * KM, x_hi * KM)
+
+    zmax = float(verts[:, 1].max()) * KM
+    emax = float(elev.max()) * KM
+    axm.set_ylim(-(emax * 1.5 + 0.05), zmax * 1.10)
+    axm.invert_yaxis()
+
+    if equal_aspect:
+        axm.set_aspect("equal", adjustable="box")
+        ve_note = "no vertical exaggeration (1:1)"
+    else:
+        bbox = axm.get_position()
+        w_in = fig.get_figwidth() * bbox.width
+        h_in = fig.get_figheight() * bbox.height
+        dx = (x_hi - x_lo) * KM
+        dz = (zmax * 1.10) + (emax * 1.5 + 0.05)
+        ve = (dz / h_in) / (dx / w_in)
+        ve_note = f"vertical exaggeration ≈ {ve:.1f}×"
+    axm.text(
+        0.985,
+        0.04,
+        ve_note,
+        transform=axm.transAxes,
+        ha="right",
+        va="bottom",
+        fontsize=7.5,
+        color="0.35",
+        style="italic",
+    )
+
+    fig.tight_layout()
+    out.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out, dpi=300)
+    pdf = out.with_suffix(".pdf")
+    fig.savefig(pdf)
+    plt.close(fig)
+    return {
+        "rms_mgal": rms,
+        "variance_reduction_pct": vr,
+        "n": int(keep.sum()),
+        "out": str(out),
+        "pdf": str(pdf),
+    }


### PR DESCRIPTION
Add 'densigrav section plot' (observed vs calculated residual Bouguer anomaly + 2-D density model with topography) and 'densigrav section ensemble' (Monte-Carlo body-presence probability map + 5-95% predictive envelope for inversion non-uniqueness). Logic in densigrav.section.plotting/ensemble; CLI wired; thin standalone scripts; README updated. Addresses the figures part of #9.

Closes #9
<img width="2250" height="1980" alt="section_Shinshiro_ensemble" src="https://github.com/user-attachments/assets/106e5869-8cc9-43a0-baac-212e2c0068e9" />

